### PR TITLE
echo vs perl

### DIFF
--- a/dovecot/dovecot-dict-sql.conf.ext
+++ b/dovecot/dovecot-dict-sql.conf.ext
@@ -1,4 +1,4 @@
-#connect = host=localhost dbname=mails user=testuser password=pass
+connect=
 
 # CREATE TABLE quota (
 #   username varchar(100) not null,

--- a/dovecot/dovecot-sql.conf.ext
+++ b/dovecot/dovecot-sql.conf.ext
@@ -63,7 +63,7 @@
 #   connect = host=sql.example.com dbname=virtual user=virtual password=blarg
 #   connect = /etc/dovecot/authdb.sqlite
 #
-#connect =
+connect=
 
 # Default password scheme.
 #

--- a/run.sh
+++ b/run.sh
@@ -13,18 +13,18 @@ hostname -f > /srv/haraka/config/me
 hostname -f > /srv/haraka/config/host_list
 
 # haraka plugin configs
-echo host=$MYSQL_HOST >> /srv/haraka/config/auth_sql_cryptmd5.ini
-echo host=$MYSQL_HOST >> /srv/haraka/config/quota.check.ini
-echo host=$MYSQL_HOST >> /srv/haraka/config/aliases_mysql.ini
-echo user=$MYSQL_USER >> /srv/haraka/config/auth_sql_cryptmd5.ini
-echo user=$MYSQL_USER >> /srv/haraka/config/quota.check.ini
-echo user=$MYSQL_USER >> /srv/haraka/config/aliases_mysql.ini
-echo password=$MYSQL_PASS >> /srv/haraka/config/auth_sql_cryptmd5.ini
-echo password=$MYSQL_PASS >> /srv/haraka/config/quota.check.ini
-echo password=$MYSQL_PASS >> /srv/haraka/config/aliases_mysql.ini
-echo database=$MYSQL_DATABASE >> /srv/haraka/config/auth_sql_cryptmd5.ini
-echo database=$MYSQL_DATABASE >> /srv/haraka/config/quota.check.ini
-echo database=$MYSQL_DATABASE >> /srv/haraka/config/aliases_mysql.ini
+/usr/bin/perl -pi -e "s/host=.*$/host=$MYSQL_HOST/" /srv/haraka/config/auth_sql_cryptmd5.ini
+/usr/bin/perl -pi -e "s/host=.*$/host=$MYSQL_HOST/" /srv/haraka/config/quota.check.ini
+/usr/bin/perl -pi -e "s/host=.*$/host=$MYSQL_HOST/" /srv/haraka/config/aliases_mysql.ini
+/usr/bin/perl -pi -e "s/user=.*$/user=$MYSQL_USER/" /srv/haraka/config/auth_sql_cryptmd5.ini
+/usr/bin/perl -pi -e "s/user=.*$/user=$MYSQL_USER/" /srv/haraka/config/quota.check.ini
+/usr/bin/perl -pi -e "s/user=.*$/user=$MYSQL_USER/" /srv/haraka/config/aliases_mysql.ini
+/usr/bin/perl -pi -e "s/password=.*$/password=$MYSQL_PASS/" /srv/haraka/config/auth_sql_cryptmd5.ini
+/usr/bin/perl -pi -e "s/password=.*$/password=$MYSQL_PASS/" /srv/haraka/config/quota.check.ini
+/usr/bin/perl -pi -e "s/password=.*$/password=$MYSQL_PASS/" /srv/haraka/config/aliases_mysql.ini
+/usr/bin/perl -pi -e "s/database=.*$/database=$MYSQL_DATABASE/" /srv/haraka/config/auth_sql_cryptmd5.ini
+/usr/bin/perl -pi -e "s/database=.*$/database=$MYSQL_DATABASE/" /srv/haraka/config/quota.check.ini
+/usr/bin/perl -pi -e "s/database=.*$/database=$MYSQL_DATABASE/" /srv/haraka/config/aliases_mysql.ini
 
 if [ -f "/tls/tls_cert.pem" -a -f "/tls/tls_key.pem" ]; then
     cp /tls/tls_*.pem /srv/haraka/config/
@@ -39,8 +39,8 @@ if [ -f "/tls/tls_cert.pem" -a -f "/tls/tls_key.pem" ]; then
 fi
 
 # dovecot sql && dict sql config
-echo connect = host=$MYSQL_HOST dbname=$MYSQL_DATABASE user=$MYSQL_USER password=$MYSQL_PASS >> /etc/dovecot/dovecot-sql.conf.ext
-echo connect = host=$MYSQL_HOST dbname=$MYSQL_DATABASE user=$MYSQL_USER password=$MYSQL_PASS >> /etc/dovecot/dovecot-dict-sql.conf.ext
+/usr/bin/perl -pi -e "s/^connect=.*?$/connect=host=$MYSQL_HOST dbname=$MYSQL_DATABASE user=$MYSQL_USER password=$MYSQL_PASS" /etc/dovecot/dovecot-sql.conf.ext
+/usr/bin/perl -pi -e "s/^connect=.*?$/connect=host=$MYSQL_HOST dbname=$MYSQL_DATABASE user=$MYSQL_USER password=$MYSQL_PASS" /etc/dovecot/dovecot-dict-sql.conf.ext
 
 # start supervisor
 exec supervisord


### PR DESCRIPTION
changed startup script from echo to perl so that on restart the values in config-files are being replaced instead of being added over and over again.
